### PR TITLE
fix(e2e): 修复字体mock的地址问题

### DIFF
--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -25,8 +25,8 @@ build-http-mocks: .node-base
 
 ci: .base
 	# 让字体走外网，防止因为连接问题导致快照错误
-	http_proxy=http://localhost:1081 curl mock-configurer/travis/mock_font_awesome
-	http_proxy=http://localhost:1081 curl mock-configurer/travis/mock_font_cdn
+	http_proxy=http://localhost:1081 curl http://mock-configurer/travis/mock_font_awesome
+	http_proxy=http://localhost:1081 curl http://mock-configurer/travis/mock_font_cdn
 	docker run --rm -t --ipc=host --network=host \
 		$(shell printenv | grep -E '^TRAVIS' | sed 's/"/\\"/g; s/\(.*\)/"\1"/g; s/^/-e /g') \
 	 	$(E2eBaseTag) \


### PR DESCRIPTION
原先的会报这样的错误： mock HTTP://mock-configurer/travis/mock_font_awesome yield
following error message: mock
HTTP://mock-configurer/travis/mock_font_awesome is not in the list
。看起来它是把域名也当成url了。