### PR TITLE
chore(travis): 在外部pr时，不启动录制信息

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,8 @@ jobs:
       script:
         - cd e2e
         - make server > /dev/null & wait-on tcp:localhost:1081
-        - make ci
+        - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then make ci-no-record; fi'
+        - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then make ci; fi'
         - make run run-cmd="npm run lint"
 
     - name: Root
@@ -65,7 +66,7 @@ jobs:
           token: $SONAR_TOKEN
       script:
         - make commitlint-travis
-        - sonar-scanner -Dsonar.projectKey=acm-statistics -Dsonar.organization=liu233w-github -Dsonar.sources=. -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONAR_TOKEN -Dsonar.exclusions=**/node_modules/**/*,backend
+        - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then sonar-scanner -Dsonar.projectKey=acm-statistics -Dsonar.organization=liu233w-github -Dsonar.sources=. -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONAR_TOKEN -Dsonar.exclusions=**/node_modules/**/*,backend; fi'
 
     - name: Deploy to DockerHub
       stage: deploy

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -35,6 +35,15 @@ ci: .base
 	 	$(E2eBaseTag) \
 		npm test -- --record --key $(CYPRESS_RECORD_KEY)
 
+ci-no-record: .base
+	# 让字体走外网，防止因为连接问题导致快照错误
+	http_proxy=http://localhost:1081 curl http://mock-configurer/travis/mock_font_awesome
+	http_proxy=http://localhost:1081 curl http://mock-configurer/travis/mock_font_cdn
+	docker run --rm -t --ipc=host --network=host \
+		$(shell printenv | grep -E '^TRAVIS' | sed 's/"/\\"/g; s/\(.*\)/"\1"/g; s/^/-e /g') \
+	 	$(E2eBaseTag) \
+		npm test
+
 run: .base
 	docker run $(run-args) $(E2eBaseTag) $(run-cmd)
 


### PR DESCRIPTION
录制（快照和sonar-cloud）需要访问加密的环境变量，这个在外部pr中是不可用的，需要禁用掉