### PR TITLE
chore(workflow): 在pr的e2e测试识别后将截图和视频上传至artifact

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -30,3 +30,18 @@ jobs:
         make wait-server
         make ci-no-record
         make run run-cmd="npm run lint" make-args="no-interactive no-tty"
+    - uses: actions/upload-artifact@v1
+      if: failure()
+      with:
+        name: e2e-screenshots
+        path: e2e/cypress/screenshots
+    - uses: actions/upload-artifact@v1
+      if: failure()
+      with:
+        name: e2e-snapshots
+        path: e2e/cypress/snapshots
+    - uses: actions/upload-artifact@v1
+      if: failure()
+      with:
+        name: e2e-videos
+        path: e2e/cypress/videos


### PR DESCRIPTION
cypress-dashboard不能在别人给我的pr里用。所以改成artifact