### PR TITLE
build(backend): fix build script

### DIFF
--- a/backend/Directory.Build.props
+++ b/backend/Directory.Build.props
@@ -1,7 +1,8 @@
 <Project>
   <!-- StyleCop Analyzers configuration -->
   <PropertyGroup>
-    <CodeAnalysisRuleSet>$(SolutionDir)StyleCop.ruleset</CodeAnalysisRuleSet>
+    <!-- Relative to project folder -->
+    <CodeAnalysisRuleSet>../../StyleCop.ruleset</CodeAnalysisRuleSet>
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>
   </PropertyGroup>
   <ItemGroup>    
@@ -9,6 +10,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <AdditionalFiles Include="$(SolutionDir)stylecop.json" Link="stylecop.json" />
+    <AdditionalFiles Include="../../stylecop.json" Link="stylecop.json" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Now the stylecop.json is respected so redundant warnings are not shown in logs.