### PR TITLE
fix(crawler): fix deprecated atcoder api

### DIFF
--- a/crawler/__test__/crawlers.test.js
+++ b/crawler/__test__/crawlers.test.js
@@ -404,8 +404,12 @@ describe('atcoder', () => {
 
   test('should work correctly', async () => {
     const res = await atcoder(null, 'wata')
-    checkRes(res)
-    expect(res.solvedList).toContain('judge_update_202004_b')
+
+    expect(typeof res.solved).toBe('number')
+    expect(typeof res.submissions).toBe('number')
+
+    expect(res.solved).toBeGreaterThan(0)
+    expect(res.submissions).toBe(res.solved)
   })
 
 })

--- a/crawler/config.yml
+++ b/crawler/config.yml
@@ -115,7 +115,7 @@ crawlers:
       title: AtCoder
       description: |
         API provided by kenkoooo (https://github.com/kenkoooo/AtCoderProblems).
-        It may take a while for the api to update user statistics.
+        Only AC number is supported
       url: https://atcoder.jp
   aizu:
     meta:

--- a/crawler/crawlers/atcoder.js
+++ b/crawler/crawlers/atcoder.js
@@ -21,21 +21,14 @@ module.exports = async function (config, username) {
   // Thank @kenkoooo for the api
   // Source code: https://github.com/kenkoooo/AtCoderProblems
   const res = await request
-    .get('https://kenkoooo.com/atcoder/atcoder-api/results')
+    .get('https://kenkoooo.com/atcoder/atcoder-api/v3/user/ac_rank')
     .query({ user: username })
 
-  const submissions = res.body.length
-  const acSet = new Set()
-  for (let item of res.body) {
-    if (item.result === 'AC') {
-      acSet.add(item.problem_id)
-    }
-  }
-  const acList = [...acSet]
+  const solved = res.body.count
+  const  submissions = solved
 
   return {
     submissions,
-    solved: acList.length,
-    solvedList: acList,
+    solved,
   }
 }

--- a/e2e/__test__/pages/__snapshots__/pages_snapshot.test.js.snap
+++ b/e2e/__test__/pages/__snapshots__/pages_snapshot.test.js.snap
@@ -4502,7 +4502,7 @@ exports[`/history/{historyId} 1`] = `
                 },
                 atcoder: {
                   title: "AtCoder",
-                  description: "API provided by kenkoooo (https:\\u002F\\u002Fgithub.com\\u002Fkenkoooo\\u002FAtCoderProblems).\\nIt may take a while for the api to update user statistics.\\n",
+                  description: "API provided by kenkoooo (https:\\u002F\\u002Fgithub.com\\u002Fkenkoooo\\u002FAtCoderProblems).\\nOnly AC number is supported\\n",
                   url: "https:\\u002F\\u002Fatcoder.jp"
                 },
                 aizu: {
@@ -8593,7 +8593,7 @@ exports[`/statistics 1`] = `
                 },
                 atcoder: {
                   title: "AtCoder",
-                  description: "API provided by kenkoooo (https:\\u002F\\u002Fgithub.com\\u002Fkenkoooo\\u002FAtCoderProblems).\\nIt may take a while for the api to update user statistics.\\n",
+                  description: "API provided by kenkoooo (https:\\u002F\\u002Fgithub.com\\u002Fkenkoooo\\u002FAtCoderProblems).\\nOnly AC number is supported\\n",
                   url: "https:\\u002F\\u002Fatcoder.jp",
                   name: w
                 },


### PR DESCRIPTION
It is not worthy to get submission count anymore. From now on, we just get the AC.