### PR TITLE
fix(crawler): try fix vjudge crawler login error detection

### DIFF
--- a/crawler/crawlers/vjudge.js
+++ b/crawler/crawlers/vjudge.js
@@ -55,7 +55,7 @@ module.exports = async function (localConfig, username) {
       throw new Error(`Server Response Error: ${res.status}`)
     }
 
-    if (res.body.error && res.body.error === 'Please login and confirm your email first') {
+    if (res.body.error && /login/.test(res.body.error)) {
       await tryLogin()
       continue
     }


### PR DESCRIPTION
The reason why it failed is that the login error message is changed. Now I changed it into a regex, so it should be able to match more situations.