### PR TITLE
build(workflow): drop codecov

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -14,7 +14,6 @@ jobs:
         # smoke test and lint
         make run run-cmd="dotnet build" make-args="no-interactive no-tty"
         make test-ci
-    - uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3
 
   crawler:
     name: Test Crawler
@@ -25,7 +24,6 @@ jobs:
         cd crawler
         make run run-cmd="npm run lint" make-args="no-interactive no-tty"
         make test-ci
-    - uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3
 
   crawler-api-backend:
     name: Test Crawler Api Backend
@@ -36,7 +34,6 @@ jobs:
         cd crawler-api-backend
         make run run-cmd="npm run lint" make-args="no-interactive no-tty"
         make test-ci
-    - uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3
 
   frontend:
     name: Test Frontend
@@ -47,7 +44,6 @@ jobs:
         cd frontend
         make run run-cmd="npm run lint" make-args="no-interactive no-tty"
         make test-ci
-    - uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3
         
   captcha-service:
     name: Test Captcha Service
@@ -58,7 +54,6 @@ jobs:
         cd captcha-service
         make run run-cmd="npm run lint" make-args="no-interactive no-tty"
         make test-ci
-    - uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3
 
   ohunt:
     name: Test OHunt
@@ -70,7 +65,6 @@ jobs:
         # smoke test and lint
         make run run-cmd="dotnet build" make-args="no-interactive no-tty"
         make test-ci
-    - uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3
 
   commitlint:
     name: Commitlint


### PR DESCRIPTION
This just makes maintenance more difficult. And it is unstable.